### PR TITLE
Issue 2 score authentication for ck board

### DIFF
--- a/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
@@ -159,7 +159,10 @@ public class WorkgroupImpl implements Workgroup, Comparable<WorkgroupImpl> {
   public String generateWorkgroupName() {
     String workgroupName = "";
     for (User member : group.getMembers()) {
-      workgroupName += " " + member.getUserDetails().getUsername();
+      if (!workgroupName.equals("")) {
+        workgroupName += " ";
+      }
+      workgroupName += member.getUserDetails().getUsername();
     }
     return workgroupName;
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
@@ -1,0 +1,197 @@
+package org.wise.portal.presentation.web.controllers;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.authentication.MutableUserDetails;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.presentation.util.http.Base64;
+import org.wise.portal.service.user.UserService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+
+@Controller
+public class CkBoardSsoController {
+  public static final String STUDENT = "student";
+  public static final String TEACHER = "teacher";
+
+  @Autowired
+  Environment appProperties;
+
+  @Autowired
+  UserService userService;
+
+  @Autowired
+  WorkgroupService workgroupService;
+
+  String ckBoardUrl;
+  String hashAlgorithm = "HmacSHA256";
+  String secretKey;
+
+  @PostConstruct
+  public void init() {
+    ckBoardUrl = appProperties.getProperty("ck_board_url");
+    secretKey = appProperties.getProperty("ck_board_sso_secret_key");
+  }
+
+  @GetMapping("/sso/ckboard")
+  protected RedirectView ckBoardSsoLogin(@RequestParam("sso") String payload,
+      @RequestParam("sig") String sig, @RequestParam("redirectUrl") String redirectUrl,
+      Authentication auth) throws IOException, UnsupportedEncodingException {
+    String nonce = getNonce(payload);
+    if (isCkBoardAvailable() && isValidHash(payload, sig) && nonce != null) {
+      User user = userService.retrieveUserByUsername(auth.getName());
+      return new RedirectView(generateCkBoardSsoLoginUrl(nonce, user, redirectUrl));
+    } else {
+      return null;
+    }
+  }
+
+  private String getNonce(String payloadEncoded) throws IOException, UnsupportedEncodingException {
+    String payload = new String(Base64.decode(payloadEncoded), "UTF-8");
+    if (payload.startsWith("nonce=")) {
+      return payload.substring(6);
+    }
+    return null;
+  }
+
+  private boolean isCkBoardAvailable() {
+    return secretKey != null && !secretKey.isEmpty() && ckBoardUrl != null && !ckBoardUrl.isEmpty();
+  }
+
+  private boolean isValidHash(String payload, String sig) {
+    return hmacDigest(payload, secretKey, hashAlgorithm).equals(sig);
+  }
+
+  private String generateCkBoardSsoLoginUrl(String nonce, User user, String redirectUrl)
+      throws UnsupportedEncodingException {
+    String payload = "";
+    if (user.isStudent()) {
+      payload = generateStudentPayload(nonce, user, redirectUrl);
+    } else if (user.isTeacher()) {
+      payload = generateTeacherPayload(nonce, user, redirectUrl);
+    }
+    String payloadBase64 = Base64.encodeBytes(payload.getBytes());
+    String payloadBase64UrlEncoded = URLEncoder.encode(payloadBase64, "UTF-8");
+    String payloadBase64Hashed = hmacDigest(payloadBase64, secretKey, hashAlgorithm);
+    return generateCkBoardSsoLoginUrlWithPayload(payloadBase64UrlEncoded, payloadBase64Hashed);
+  }
+
+  private String generateTeacherPayload(String nonce, User user, String redirectUrl)
+      throws UnsupportedEncodingException {
+    MutableUserDetails userDetails = user.getUserDetails();
+    String username = URLEncoder.encode(userDetails.getUsername(), "UTF-8");
+    String email = URLEncoder.encode(userDetails.getEmailAddress(), "UTF-8");
+    String redirectUrlWithoutParams = getRedirectUrlWithoutParams(redirectUrl);
+    return generatePayload(nonce, username, email, redirectUrlWithoutParams, null, TEACHER);
+  }
+
+  private String generateStudentPayload(String nonce, User user, String redirectUrl)
+      throws UnsupportedEncodingException {
+    Long workgroupId = null;
+    String username = null;
+    try {
+      Long workgroupIdFromRedirectUrl = getWorkgroupIdFromRedirectUrl(redirectUrl);
+      Workgroup workgroup = workgroupService.retrieveById(workgroupIdFromRedirectUrl);
+      if (workgroup.getMembers().contains(user)) {
+        workgroupId = workgroupIdFromRedirectUrl;
+        username = workgroup.generateWorkgroupName();
+      }
+    } catch(ObjectNotFoundException e) {
+      e.printStackTrace();
+    }
+    String redirectUrlWithoutParams = getRedirectUrlWithoutParams(redirectUrl);
+    return generatePayload(nonce, username, null, redirectUrlWithoutParams, workgroupId, STUDENT);
+  }
+
+  private String getRedirectUrlWithoutParams(String redirectUrl) {
+    String redirectUrlWithoutParams = null;
+    try {
+      URI uri = new URI(redirectUrl);
+      redirectUrlWithoutParams = uri.getPath();
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return redirectUrlWithoutParams;
+  }
+
+  private Long getWorkgroupIdFromRedirectUrl(String redirectUrl) {
+    Long workgroupId = null;
+    try {
+      List<NameValuePair> params =
+          URLEncodedUtils.parse(new URI(redirectUrl), Charset.forName("UTF-8"));
+      for (NameValuePair param : params) {
+        if (param.getName().equals("workgroup-id")) {
+          workgroupId = Long.parseLong(param.getValue());
+        }
+      }
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return workgroupId;
+  }
+
+  private String generatePayload(String nonce, String username, String email, String redirectUrl,
+      Long workgroupId, String role) {
+    StringBuilder payloadBuffer = new StringBuilder();
+    payloadBuffer.append("nonce=" + nonce + "&");
+    payloadBuffer.append("username=" + username + "&");
+    payloadBuffer.append("redirect-url=" + redirectUrl + "&");
+    if (email != null) {
+      payloadBuffer.append("email=" + email + "&");
+    }
+    if (workgroupId != null) {
+      payloadBuffer.append("workgroup-id=" + workgroupId + "&");
+    }
+    payloadBuffer.append("role=" + role);
+    return payloadBuffer.toString();
+  }
+
+  private String generateCkBoardSsoLoginUrlWithPayload(String payload, String hashedPayload) {
+    return ckBoardUrl + "/session/sso_login/" + payload + "/" + hashedPayload;
+  }
+
+  public static String hmacDigest(String msg, String secretKey, String algorithm) {
+    String digest = null;
+    try {
+      SecretKeySpec key = new SecretKeySpec((secretKey).getBytes("UTF-8"), algorithm);
+      Mac mac = Mac.getInstance(algorithm);
+      mac.init(key);
+      byte[] bytes = mac.doFinal(msg.getBytes("ASCII"));
+      StringBuffer hash = new StringBuffer();
+      for (int i = 0; i < bytes.length; i++) {
+        String hex = Integer.toHexString(0xFF & bytes[i]);
+        if (hex.length() == 1) {
+          hash.append('0');
+        }
+        hash.append(hex);
+      }
+      digest = hash.toString();
+    } catch (UnsupportedEncodingException e) {
+    } catch (InvalidKeyException e) {
+    } catch (NoSuchAlgorithmException e) {
+    }
+    return digest;
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
@@ -2,8 +2,6 @@ package org.wise.portal.presentation.web.controllers;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/CkBoardSsoController.java
@@ -169,7 +169,7 @@ public class CkBoardSsoController {
   }
 
   private String generateCkBoardSsoLoginUrlWithPayload(String payload, String hashedPayload) {
-    return ckBoardUrl + "/session/sso_login/" + payload + "/" + hashedPayload;
+    return ckBoardUrl + "/sso/login/" + payload + "/" + hashedPayload;
   }
 
   public static String hmacDigest(String msg, String secretKey, String algorithm) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -744,7 +744,6 @@ public class InformationController {
     config.put("renewSessionURL", contextPath + "/api/session/renew");
     config.put("sessionTimeout", request.getSession().getMaxInactiveInterval());
     config.put("sessionLogOutURL", contextPath + "/api/logout");
-    config.put("ckBoardUrl", appProperties.getProperty("ck_board_url"));
 
     User signedInUser = ControllerUtil.getSignedInUser();
     setUserLocale(request, signedInUser, config);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -744,6 +744,7 @@ public class InformationController {
     config.put("renewSessionURL", contextPath + "/api/session/renew");
     config.put("sessionTimeout", request.getSession().getMaxInactiveInterval());
     config.put("sessionLogOutURL", contextPath + "/api/logout");
+    config.put("ckBoardUrl", appProperties.getProperty("ck_board_url"));
 
     User signedInUser = ControllerUtil.getSignedInUser();
     setUserLocale(request, signedInUser, config);

--- a/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebSecurityConfig.java
@@ -103,6 +103,7 @@ public class WebSecurityConfig<S extends Session>
         .antMatchers("/teacher/**").hasAnyRole("TEACHER")
         .antMatchers("/score/**/**").permitAll()
         .antMatchers("/sso/discourse").hasAnyRole("TEACHER","STUDENT")
+        .antMatchers("/sso/ckboard").hasAnyRole("TEACHER","STUDENT")
         .antMatchers("/teachingassistant/**/**").permitAll()
         .antMatchers("/api/**/**").permitAll()
         .antMatchers("/").permitAll();

--- a/src/test/java/org/wise/portal/presentation/web/controllers/CkBoardSsoControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/CkBoardSsoControllerTest.java
@@ -1,0 +1,39 @@
+package org.wise.portal.presentation.web.controllers;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RunWith(EasyMockRunner.class)
+public class CkBoardSsoControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private CkBoardSsoController ckBoardSsoController = new CkBoardSsoController();
+
+  @Test
+  public void ckBoardSsoLogin() throws Exception {
+    expect(appProperties.getProperty("ck_board_url")).andReturn("http://localhost:4201");
+    expect(appProperties.getProperty("ck_board_sso_secret_key")).andReturn("VV5jf6rXt4zrbBuH");
+    expect(userService.retrieveUserByUsername(teacherAuth.getName())).andReturn(teacher1);
+    replay(appProperties, userService);
+    String payload = "bm9uY2U9ZTFiYzIwM2YtYTE0My00ODgzLWI1OGQtODJjNzgyN2JjNjU5";
+    String sig = "b98379e2e6d3e86a03e281f8d96bf7335d1ffc1670b69bb79f23e1cbfc20e676";
+    String redirectUrl = "/dashboard";
+    ckBoardSsoController.init();
+    RedirectView ckBoardSsoLoginRedirect = ckBoardSsoController.ckBoardSsoLogin(payload, sig,
+        redirectUrl, teacherAuth);
+    String expectedckBoardSsoLoginRedirectUrl = "http://localhost:4201/sso/login/bm9uY2U9ZTFiYzIwM2"
+        + "YtYTE0My00ODgzLWI1OGQtODJjNzgyN2JjNjU5JnVzZXItaWQ9OTQyMTAmdXNlcm5hbWU9U3F1aWR3YXJkVGVudG"
+        + "FjbGVzJnJvbGU9dGVhY2hlciZyZWRpcmVjdC11cmw9L2Rhc2hib2FyZA%3D%3D/f842d22f6cedb8541297337eb"
+        + "c27b115d93f6fcc6cab4989a78bd2cb96d141ea";
+    assertEquals(expectedckBoardSsoLoginRedirectUrl, ckBoardSsoLoginRedirect.getUrl());
+    verify(appProperties, userService);
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -190,5 +190,9 @@ google.tokens.dir=
 #discourse_url=http://localhost:4000
 #discourse_sso_secret_key=do_the_right_thing
 
+### CK Board Single Sign-On ###
+ck_board_url=
+ck_board_sso_secret_key=
+
 # backwards compatibility purpose only.
 system-wide-salt=secret


### PR DESCRIPTION
Note: Make sure to go into application-dockerdev.properties and set values for the new CK Board properties. The ck_board_sso_secret_key can be anything as long as you use the same one in the ck-board .env file.

```
ck_board_url=http://localhost:4201
ck_board_sso_secret_key=VV5jf6rXt4zrbBuH
```

## Changes

- Added SSO endpoint for CK Board to access
- Handled redirect url when accessing a CK Board url using SCORE authentication
- Added CK Board properties to application.properties

## Test

- CK Board can use SCORE for authentication
- CK Board is properly redirected to the CK Board url that you originally tried to access before signing in to SCORE (for example if you are signed out of CK Board and then you try to access a board directly like http://localhost:4201/project/e347aab0-6623-4ffb-8950-191192956cac/board/eaee497d-3730-451f-a939-a4e5416a9d96, it should ask you to sign in to SCORE, and then it should redirect you to the board)

Closes #2