### PR TITLE
feat(CK Board): Log out of CK Board when user logs out of SCORE

### DIFF
--- a/.project
+++ b/.project
@@ -47,12 +47,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1598983010649</id>
+			<id>1671208548449</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/src/main/java/org/wise/portal/service/session/SessionService.java
+++ b/src/main/java/org/wise/portal/service/session/SessionService.java
@@ -3,6 +3,8 @@ package org.wise.portal.service.session;
 import java.io.Serializable;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.security.core.userdetails.UserDetails;
 
 public interface SessionService {
@@ -28,4 +30,8 @@ public interface SessionService {
   void removeCurrentAuthor(Serializable projectdId, String authorUsername);
 
   void removeUser(UserDetails user);
+
+  boolean isCkBoardAvailable();
+
+  void signOutOfCkBoard(HttpServletRequest request);
 }

--- a/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
+++ b/src/main/java/org/wise/portal/spring/impl/WISELogoutHandler.java
@@ -38,17 +38,20 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.session.Session;
 import org.wise.portal.service.session.SessionService;
 
-public class WISELogoutHandler<S extends Session> implements LogoutHandler, 
-    ApplicationListener<SessionDestroyedEvent> {
+public class WISELogoutHandler<S extends Session>
+    implements LogoutHandler, ApplicationListener<SessionDestroyedEvent> {
 
   @Autowired
   protected SessionService sessionService;
 
   @Override
-  public void logout(HttpServletRequest request, HttpServletResponse response, 
+  public void logout(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) {
     if (authentication != null) {
       sessionService.removeUser((UserDetails) authentication.getPrincipal());
+      if (sessionService.isCkBoardAvailable()) {
+        sessionService.signOutOfCkBoard(request);
+      }
     }
   }
 

--- a/src/main/resources/application-dockerdev.properties
+++ b/src/main/resources/application-dockerdev.properties
@@ -193,5 +193,8 @@ google.tokens.dir=
 ck_board_url=
 ck_board_sso_secret_key=
 
+# Only set this when in local development environment
+#ck_board_local_backend_url=
+
 # backwards compatibility purpose only.
 system-wide-salt=secret


### PR DESCRIPTION
## Changes

When a user signs out of SCORE, we also sign out of CK Board.

## Test

Test with the ck-board branch from this PR
- https://github.com/encorelab/ck-board/pull/412

1. Find your local IP by running this in the Terminal.
```
ipconfig getifaddr en0
```

2. Modify your `src/main/resources/application-dockerdev.properties` file by adding this new property below. Replace `192.168.86.29` with your local IP.
```
ck_board_local_backend_url=http://192.168.86.29:8001
```

3. Start up SCORE, ck-board frontend, and ck-board backend.

4. Sign in to SCORE.
5. Open CK Board in a new tab. You should be automatically logged in.
6. Sign out of SCORE.
7. Go to the CK Board tab and refresh it. You should be logged out of CK Board and it should redirect you to the sign in page.

Closes #7